### PR TITLE
SD-94: Changed version number to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-uk-local-authorities",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "Exports a list of uk local authorities for the modern slavery app into a usable format for hof select elements",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Jira Ticket: https://collaboration.homeoffice.gov.uk/jira/browse/SD-94

Version number changed to 2.2.1, to allow for changes to borough councils.